### PR TITLE
Gnome 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "Auto selects headsets when possible instead of showing a dialog",
   "uuid": "autoselectheadset@josephlbarnett.github.com",
   "url": "https://github.com/josephlbarnett/autoselectheadset-gnome-shell-extension",
-  "version": "6",
+  "version": "7",
   "shell-version": [
-    "3.38", "40", "41", "42", "43"
+    "3.38", "40", "41", "42", "43", "44"
   ]
 }


### PR DESCRIPTION
- Tested on Fedora 38 with Gnome 44.1. Works fine with external audio system jack and headphones with mic jack, no errors in journalctl
- Bumped extension version