### PR TITLE
Gnome 45 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "Auto selects headsets when possible instead of showing a dialog",
   "uuid": "autoselectheadset@josephlbarnett.github.com",
   "url": "https://github.com/josephlbarnett/autoselectheadset-gnome-shell-extension",
-  "version": "7",
+  "version": "8",
   "shell-version": [
-    "3.38", "40", "41", "42", "43", "44"
+    "45"
   ]
 }


### PR DESCRIPTION
Changes:
- metadata.json shell version has now only 45. Because of ecma modules we cannot be backwards compatible anymore.
- Adapted imports and used the new Extension class format.
- Made 'originalOpenAsync' a private field and converted also the 'replace' method to private.
- Bumped version number in metadata.json.

Unfortunately I was able to test these changes only inside a Fedora Rawhide Virtual Machine (so no real sound devices). There were no errors in journalctl when enabling/disabling the extension. Hopefully the replacement method still works fine with 45 on a real hardware.